### PR TITLE
updated toolchain to wasm-tools to support gc

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,8 +6,8 @@ OUTPUT_EC_DIR = wasm-ec
 
 # Tools
 CLANG = /opt/wasi-sdk/bin/clang
-WAT2WASM = wat2wasm
-WASM2WAT = wasm2wat
+WAT2WASM = wasm-tools parse
+WASM2WAT = wasm-tools print
 
 # File extensions
 C_EXT = .c


### PR DESCRIPTION
The current test framework uses `wasm2wat` which is updated and has no support for GC. I've updated it to [wasm-tools](https://github.com/bytecodealliance/wasm-tools/tree/main) which has been updated to support GC.